### PR TITLE
fix: move sync job later in the morning

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -2,7 +2,7 @@ name: Sync Metrics
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 6 * * *"  # at 06:17 UTC (just before the hour to avoid the rush on GH runners)
+    - cron: "17 8 * * *"  # at 08:17 UTC (just before the hour to avoid the rush on GH runners)
 
 jobs:
   update_metrics:


### PR DESCRIPTION
# Summary
With the increased metrics data size, generating the CSVs now takes longer.
This fix gives the generate job time to complete before the sync occurs.